### PR TITLE
Support non-colorized output in xrop.

### DIFF
--- a/include/color_print.h
+++ b/include/color_print.h
@@ -21,7 +21,6 @@ enum colors
     Cyan,
     BrightWhite,
     White,
-    NoColor,
     LessBright,
     END_COLORS
 };

--- a/include/color_print.h
+++ b/include/color_print.h
@@ -1,0 +1,39 @@
+#ifndef COLOR_PRINT_H
+#define COLOR_PRINT_H
+
+extern int xrop_no_color_g;
+
+enum colors
+{
+    BrightBlack=0,
+    Black,  //more like gray
+    BrightRed,
+    Red,
+    BrightGreen,
+    Green,
+    BrightYellow,
+    Yellow,
+    BrightBlue,
+    Blue,
+    BrightMagenta,
+    Magenta,
+    BrightCyan,
+    Cyan,
+    BrightWhite,
+    White,
+    NoColor,
+    LessBright,
+    END_COLORS
+};
+
+void __color_printf(enum colors colorcode, const char* format, ...);
+
+#define br_blue_printf(...)     __color_printf(BrightBlue,__VA_ARGS__)
+#define blue_printf(...)        __color_printf(Blue,__VA_ARGS__)
+#define br_red_printf(...)      __color_printf(BrightRed,__VA_ARGS__)
+#define red_printf(...)         __color_printf(Red,__VA_ARGS__)
+#define br_green_printf(...)    __color_printf(BrightGreen,__VA_ARGS__)
+#define green_printf(...)       __color_printf(Green,__VA_ARGS__)
+#define dim_printf(...)         __color_printf(LessBright,__VA_ARGS__)
+
+#endif /* COLOR_PRINT_H */

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,8 +13,8 @@ makelib:
 	cd libxdisasm && $(MAKE)
 	cp libxdisasm/build/lib/libxdisasm.so ../lib/libxdisasm.so
 
-xropbin: main.o xrop.o x86-gen.o common.o arm-gen.o mips-gen.o ppc-gen.o riscv-gen.o sh4-gen.o sparc-gen.o
-	$(CC) $(CFLAGS) xrop.o main.o common.o x86-gen.o arm-gen.o mips-gen.o ppc-gen.o riscv-gen.o sh4-gen.o sparc-gen.o -o ${APP} $(LDFLAGS)
+xropbin: main.o xrop.o x86-gen.o common.o arm-gen.o mips-gen.o ppc-gen.o riscv-gen.o sh4-gen.o sparc-gen.o color_print.o
+	$(CC) $(CFLAGS) xrop.o main.o common.o x86-gen.o arm-gen.o mips-gen.o ppc-gen.o riscv-gen.o sh4-gen.o sparc-gen.o color_print.o -o ${APP} $(LDFLAGS)
 	strip -s ${APP}
 
 clean:

--- a/src/color_print.c
+++ b/src/color_print.c
@@ -34,7 +34,7 @@ static char *foreground_colors[END_COLORS]={
 
 void __color_printf(enum colors colorcode, const char* format, ...)
 {
-    int print_colors=(!xrop_no_color_g && (colorcode < sizeof(foreground_colors)));
+    int print_colors=(!xrop_no_color_g && (colorcode < sizeof(foreground_colors)/sizeof(char *)));
     if(print_colors)
     {
         printf("%s",foreground_colors[colorcode]);

--- a/src/color_print.c
+++ b/src/color_print.c
@@ -1,0 +1,50 @@
+#include "../include/print_color.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+
+int xrop_no_color_g=0;
+
+/* Color table
+ *                     Black	Red     Green	Yellow	Blue	Magenta	Cyan	White
+ * Foreground Code	    30	    31	    32	    33	    34	    35	    36	    37
+ * Background Code	    40	    41	    42	    43	    44	    45      46	    47
+ */
+
+static char *foreground_colors[END_COLORS]={
+    "\e[30;1m", //Bright black/gray
+    "\e[30m",   //Black
+    "\e[31;1m", //Bright Read
+    "\e[31m",   //Red
+    "\e[32;1m", //Bright Green
+    "\e[32m",   //Green
+    "\e[33;1m", //Bright Yellow
+    "\e[33m",   //Yellow
+    "\e[34;1m", //Bright Blue
+    "\e[34m",   //Blue
+    "\e[35;1m", //Bright Magenta
+    "\e[35m",   //Magenta
+    "\e[36;1m", //Bright Cyan
+    "\e[36m",   //Cyan
+    "\e[37;1m", //Bright White
+    "\e[37m",   //White
+    "\e[2m"
+};
+
+
+void __color_printf(enum colors colorcode, const char* format, ...)
+{
+    int print_colors=(!xrop_no_color_g && (colorcode < sizeof(foreground_colors)));
+    if(print_colors)
+    {
+        printf("%s",foreground_colors[colorcode]);
+    }
+    va_list argptr;
+    va_start(argptr, format);
+    vfprintf(stdout, format, argptr);
+    va_end(argptr);
+    if(print_colors)
+    {
+        printf("\e[m");
+    }
+}

--- a/src/color_print.c
+++ b/src/color_print.c
@@ -28,7 +28,7 @@ static char *foreground_colors[END_COLORS]={
     "\e[36m",   //Cyan
     "\e[37;1m", //Bright White
     "\e[37m",   //White
-    "\e[2m"
+    "\e[2m"     //Dim
 };
 
 

--- a/src/common.c
+++ b/src/common.c
@@ -20,6 +20,7 @@
 */
 
 #include "../include/xrop.h"
+#include "../include/color_print.h"
 #include <stdio.h>
 #include <string.h>
 #include <regex.h>
@@ -156,7 +157,7 @@ int is_branch(insn_t * i, int arch){
 
 // insn_t * -> void
 // Print a gadget in a formatted way (with colors)
-void print_gadget(insn_t * ins, int type, int isthumb){
+static void print_gadget(insn_t * ins, int type, int isthumb){
     char * dec = NULL, * ptr = NULL;
     size_t i, l;
     char * opcode_str = NULL;
@@ -175,14 +176,14 @@ void print_gadget(insn_t * ins, int type, int isthumb){
 
     if(type == END_OUTPUT || type == SPECIAL_OUTPUT){
         if(isthumb)
-            printf("\e[34;1m> 1 + %-12p\e[m", (void *)ins->vma);
+            br_blue_printf("> 1 + %-16p", (void *)ins->vma);
         else 
-            printf("\e[34;1m> %-16p\e[m", (void *)ins->vma);
+            br_blue_printf("> %-20p", (void *)ins->vma);
     }else{
         if(isthumb)
-            printf("\e[34m1 + %-14p\e[m", (void *)ins->vma);
+            blue_printf(" + %-18p", (void *)ins->vma);
         else 
-            printf("\e[34m%-18p\e[m", (void *)ins->vma);
+            blue_printf("%-22p", (void *)ins->vma);
     }
 
     for(i = 0; i < l; i++){
@@ -190,7 +191,7 @@ void print_gadget(insn_t * ins, int type, int isthumb){
         ptr += 2;
     }
 
-    printf("\e[2m%-26s\e[m", opcode_str);
+    dim_printf("%-26s", opcode_str);
 
     // remove uninteresting comments inserted by disassembler
     if((ptr = strstr(dec, "; <U"))){  // "; <UNPREDICTABLE>"
@@ -201,7 +202,7 @@ void print_gadget(insn_t * ins, int type, int isthumb){
     }
     
     if(type == BEG_OUTPUT || type == SPECIAL_OUTPUT){
-        printf("\e[31m%s\n\e[m", ins->decoded_instrs);
+        red_printf("%s\n", ins->decoded_instrs);
     }else{
         printf("%s\n", ins->decoded_instrs);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,7 @@
 
 #include "libxdisasm/include/xdisasm.h"
 #include "../include/xrop.h"
+#include "../include/color_print.h"
 
 #define VERSION "1.1"
 #define XNAME "xrop"
@@ -135,10 +136,14 @@ int handle_execable(char * infile, size_t depth, char ** re){
             endian = 1;
 
     if(barch == bfd_arch_arm){ // ARM
-        printf("Searching ROP gadgets for \"%s\" - \e[32mARM Executable\e[m...\n", infile);
+        printf("Searching ROP gadgets for \"%s\" - ",infile);
+        green_printf("ARM Executable");
+        printf("...\n");
         arch = ARCH_arm;
     }else if(barch == bfd_arch_aarch64){
-        printf("Searching ROP gadgets for \"%s\" - \e[32mARM64 Executable\e[m...\n", infile);
+        printf("Searching ROP gadgets for \"%s\" - ",infile);
+        green_printf("ARM64 Executable");
+        printf("...\n");
         arch = ARCH_arm;
         bits = 64;
     }else if(!strcmp(bfdh->xvec->name, "pei-arm-little")){ // workaround since binutils not 
@@ -150,31 +155,45 @@ int handle_execable(char * infile, size_t depth, char ** re){
             printf("Searching ROP gadgets for 16-bit is not supported\n");
             exit(-1);
         }else if(mach == bfd_mach_i386_i386){
-            printf("Searching ROP gadgets for \"%s\" - \e[32mx86 Executable\e[m...\n", infile);
+            printf("Searching ROP gadgets for \"%s\" - ",infile);
+            green_printf("x86 Executable");
+            printf("...\n");
             bits = 32;
         }else{
-            printf("Searching ROP gadgets for \"%s\" - \e[32mx86_64 Executable\e[m...\n", infile);
+            printf("Searching ROP gadgets for \"%s\" - ",infile);
+            green_printf("x86_64 Executable");
+            printf("...\n");
             bits = 64;
         }
     }else if(barch == bfd_arch_mips){ // MIPS 
-        printf("Searching ROP gadgets for \"%s\" - \e[32mMIPS Executable\e[m...\n", infile);
+        printf("Searching ROP gadgets for \"%s\" - ",infile);
+        green_printf("MIPS Executable");
+        printf("...\n");
         arch = ARCH_mips;
         sdepth = MIPS_DEFAULT_DEPTH;
     }else if(barch == bfd_arch_powerpc){ // PPC
-        printf("Searching ROP gadgets for \"%s\" - \e[32mPowerPC Executable\e[m...\n", infile);
+        printf("Searching ROP gadgets for \"%s\" - ",infile);
+        green_printf("PowerPC Executable");
+        printf("...\n");
         arch = ARCH_powerpc;
         sdepth = PPC_DEFAULT_DEPTH;
     }else if(barch == bfd_arch_riscv){ // RISCV
-        printf("Searching ROP gadgets for \"%s\" - \e[32mRISCV Executable\e[m...\n", infile);
+        printf("Searching ROP gadgets for \"%s\" - ",infile);
+        green_printf("RISCV Executable");
+        printf("...\n");
         arch = ARCH_riscv;
         bits = 64; 
         sdepth = RISCV_DEFAULT_DEPTH;
     }else if(barch == bfd_arch_sh){ // SH4
-        printf("Searching ROP gadgets for \"%s\" - \e[32mSH4 Executable\e[m...\n", infile);
+        printf("Searching ROP gadgets for \"%s\" - ",infile);
+        green_printf("SH4 Executable");
+        printf("...\n");
         arch = ARCH_sh4;
         sdepth = SH4_DEFAULT_DEPTH;
     }else if(barch == bfd_arch_sparc){ // SPARC
-        printf("Searching ROP gadgets for \"%s\" - \e[32mSPARC Executable\e[m...\n", infile);
+        printf("Searching ROP gadgets for \"%s\" - ",infile);
+        green_printf("SPARC Executable", infile);
+        printf("...\n");
         arch = ARCH_sparc;
         bits = mach; // special meaning for SPARC
         sdepth = SPARC_DEFAULT_DEPTH;
@@ -207,7 +226,7 @@ int handle_execable(char * infile, size_t depth, char ** re){
             // means this is an ELF so we only care about segments
             if(in_exec_range(exec_segments, num_segments, cur_vma, cur_vma_end)){
                 printf("\n");
-                printf("\e[32m -> [ %s ]\e[m\n", bfd_section_name(bfdh, section));
+                green_printf(" -> [ %s ]\n", bfd_section_name(bfdh, section));
 
                 cfg.arch = arch;
                 cfg.bits = bits;
@@ -220,7 +239,7 @@ int handle_execable(char * infile, size_t depth, char ** re){
         }else if((flags & SEC_LOAD) && (flags & SEC_CODE)){
             // some other file format
             printf("\n");
-            printf("\e[32m -> [ %s ]\e[m\n", bfd_section_name(bfdh, section));
+            green_printf(" -> [ %s ]\n", bfd_section_name(bfdh, section));
 
             cfg.arch = arch;
             cfg.bits = bits;
@@ -326,6 +345,10 @@ int main(int argc, char **argv){
             case 'a':
                 aval = optarg;
                 break;
+            case 'n':
+                xrop_no_color_g=1;
+                xdisasm_no_color_g=1;
+                break;
             case 's':
                 if(!re){
                     re = calloc(MAX_REGEX + 1, sizeof(char *));
@@ -369,7 +392,7 @@ int main(int argc, char **argv){
 
     // load address
     if(aval){
-        vma = strtol(aval, NULL, 0);
+        vma = strtoull(aval, NULL, 0);
         if(vma == LONG_MAX || vma == LONG_MIN || vma == 0){
             perror("strtol");
             exit(-1);


### PR DESCRIPTION
I wanted to output to a file or to grep, less, etc. and so I needed output without the ANSI color escapes. I saw that the -n option was specified in help but not yet implemented. This patch implements that option.

I also fixed rebasing to support large rebase values in the 64-bit address space, by using strtoull instead of strtol. I adjusted the spacing accordingly in the output.

